### PR TITLE
Throw a NonFatalError for throughput exceeded on a VersionedDao.getRecord

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+When calling `VersionedDao.getRecord`, a `DynamoThroughputExceededException`
+is wrapped as a `DynamoNonFatalError` in the same was as `updateRecord`.

--- a/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/dynamo/VersionedDao.scala
@@ -83,6 +83,9 @@ class VersionedDao @Inject()(
         None
       }
     }
+  }.recover {
+    case t: ProvisionedThroughputExceededException =>
+      throw DynamoNonFatalError(t)
   }
 
   private def updateBuilder[T](record: T)(

--- a/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -306,18 +306,18 @@ class VersionedDaoTest
         val expectedException = DynamoNonFatalError(exceptionThrownByGetItem)
 
         assertGetFailsWithCorrectException(
-          expectionThrownByGetItem = expectionThrownByGetItem,
+          exceptionThrownByGetItem = exceptionThrownByGetItem,
           expectedException = expectedException
         )
       }
 
       def assertGetFailsWithCorrectException(
-        expectionThrownByGetItem: Throwable,
+        exceptionThrownByGetItem: Throwable,
         expectedException: Throwable) = {
           withLocalDynamoDbTable { table =>
             val mockDynamoDbClient = mock[AmazonDynamoDB]
             when(mockDynamoDbClient.getItem(any[GetItemRequest]))
-              .thenThrow(expectionThrownByGetItem)
+              .thenThrow(exceptionThrownByGetItem)
 
             val failingDao = new VersionedDao(
               dynamoDbClient = mockDynamoDbClient,

--- a/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/dynamo/VersionedDaoTest.scala
@@ -266,13 +266,13 @@ class VersionedDaoTest
     }
 
     describe("DynamoDB failures") {
-      it("returns a DynamoNonFatalError if we exceed throughput limits") {
+      it("returns a DynamoNonFatalError if we exceed throughput limits on an UpdateItem") {
         val exceptionThrownByUpdateItem = new ProvisionedThroughputExceededException(
           "You tried to write to DynamoDB too quickly!"
         )
         val expectedException = DynamoNonFatalError(exceptionThrownByUpdateItem)
 
-        assertRequestFailsWithCorrectException(
+        assertUpdateFailsWithCorrectException(
           exceptionThrownByUpdateItem = exceptionThrownByUpdateItem,
           expectedException = expectedException
         )
@@ -284,7 +284,7 @@ class VersionedDaoTest
         )
         val expectedException = DynamoNonFatalError(exceptionThrownByUpdateItem)
 
-        assertRequestFailsWithCorrectException(
+        assertUpdateFailsWithCorrectException(
           exceptionThrownByUpdateItem = exceptionThrownByUpdateItem,
           expectedException = expectedException
         )
@@ -293,13 +293,47 @@ class VersionedDaoTest
       it("returns the raw exception if there's an unexpected error") {
         val exception = new RuntimeException("AAAAAARGH!")
 
-        assertRequestFailsWithCorrectException(
+        assertUpdateFailsWithCorrectException(
           exceptionThrownByUpdateItem = exception,
           expectedException = exception
         )
       }
 
-      def assertRequestFailsWithCorrectException(
+      it("returns a DynamoNonFatalError if we exceed throughput limits on a GetItem") {
+        val exceptionThrownByGetItem = new ProvisionedThroughputExceededException(
+          "You tried to read from DynamoDB too quickly!"
+        )
+        val expectedException = DynamoNonFatalError(exceptionThrownByGetItem)
+
+        assertGetFailsWithCorrectException(
+          expectionThrownByGetItem = expectionThrownByGetItem,
+          expectedException = expectedException
+        )
+      }
+
+      def assertGetFailsWithCorrectException(
+        expectionThrownByGetItem: Throwable,
+        expectedException: Throwable) = {
+          withLocalDynamoDbTable { table =>
+            val mockDynamoDbClient = mock[AmazonDynamoDB]
+            when(mockDynamoDbClient.getItem(any[GetItemRequest]))
+              .thenThrow(expectionThrownByGetItem)
+
+            val failingDao = new VersionedDao(
+              dynamoDbClient = mockDynamoDbClient,
+              dynamoConfig = DynamoConfig(
+                table = table.name,
+                index = table.index
+              )
+            )
+
+            whenReady(failingDao.getRecord[TestVersioned](id = "123").failed) { ex =>
+              ex shouldBe expectedException
+            }
+          }
+        }
+
+      def assertUpdateFailsWithCorrectException(
         exceptionThrownByUpdateItem: Throwable,
         expectedException: Throwable) = {
         withLocalDynamoDbTable { table =>


### PR DESCRIPTION
Because it's currently causing long tracebacks in the recorder!