### PR TITLE
Close stream when reading an object with the ObjectStore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Close the input stream when retrieving an object with an ObjectStore

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     val scalaCheck = "1.13.4"
     val scalatest = "3.0.1"
     val scanamo = "1.0.0-M3"
+    val apacheCommons = "2.6"
   }
 
   val circeDependencies = Seq(
@@ -48,6 +49,9 @@ object Dependencies {
   val diDependencies = Seq(
     "com.google.inject" % "guice" % versions.guice
   )
+  
+  val apacheCommons = Seq(
+    "commons-io" % "commons-io" % versions.apacheCommons % "test")
 
   val libraryDependencies = Seq(
     "com.amazonaws" % "aws-java-sdk-dynamodb" % versions.aws,
@@ -59,5 +63,6 @@ object Dependencies {
     diDependencies ++
     scalacheckDependencies ++
     testDependencies ++
+    apacheCommons ++
     WellcomeDependencies.jsonLibrary
 }

--- a/src/main/scala/uk/ac/wellcome/storage/ObjectStore.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/ObjectStore.scala
@@ -60,8 +60,11 @@ object ObjectStore {
     }
 
     def get(objectLocation: ObjectLocation): Future[T] = {
-      val input: Future[InputStream] = storageBackend.get(objectLocation)
-      input.flatMap(input => Future.fromTry(storageStrategy.fromStream(input)))
+      for {
+        input <- storageBackend.get(objectLocation)
+        a <- Future.fromTry(storageStrategy.fromStream(input))
+        _  <- Future{if (a.isInstanceOf[InputStream]) () else input.close()}
+      } yield a
     }
   }
 }

--- a/src/main/scala/uk/ac/wellcome/storage/ObjectStore.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/ObjectStore.scala
@@ -63,7 +63,7 @@ object ObjectStore {
       for {
         input <- storageBackend.get(objectLocation)
         a <- Future.fromTry(storageStrategy.fromStream(input))
-        _  <- Future{if (a.isInstanceOf[InputStream]) () else input.close()}
+        _ <- Future { if (a.isInstanceOf[InputStream]) () else input.close() }
       } yield a
     }
   }

--- a/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/s3/S3StorageBackend.scala
@@ -84,10 +84,8 @@ class S3StorageBackend @Inject()(s3Client: AmazonS3)(
       s3Client.getObject(bucketName, key).getObjectContent
     }
 
-    futureInputStream.foreach {
-      case _ =>
-        debug(s"Success: GET object from s3://$bucketName/$key")
-    }
+    futureInputStream.foreach(_ =>
+      debug(s"Success: GET object from s3://$bucketName/$key"))
 
     futureInputStream
   }


### PR DESCRIPTION
So that we don't see so many " Unable to execute HTTP request: Timeout waiting for connection from pool" errors in the logs