### PR TITLE
Add a new VHSEntry case class which contains both the HybridRecord and Metadata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: minor
+
+Adds a new class `VHSEntry[M](hybridRecord: HybridRecord, metadata: M)` which is
+returned as the result of a call to `updateRecord`.  Previous tuple unpacking should
+still work.
+
+Additionally, fixes a bug where `updateRecord` would return incorrect metadata when
+updating an existing record.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,7 @@
 RELEASE_TYPE: minor
 
-Adds a new class `VHSEntry[M](hybridRecord: HybridRecord, metadata: M)` which is
-returned as the result of a call to `updateRecord`.  Previous tuple unpacking should
-still work.
+Adds a new class `VHSIndexEntry[M](hybridRecord: HybridRecord, metadata: M)` which is
+returned as the result of a call to `updateRecord`.
 
 Additionally, fixes a bug where `updateRecord` would return incorrect metadata when
 updating an existing record.

--- a/src/main/scala/uk/ac/wellcome/storage/vhs/VHSEntry.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/vhs/VHSEntry.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.storage.vhs
+
+case class VHSEntry[M](
+  hybridRecord: HybridRecord,
+  metadata: M
+)

--- a/src/main/scala/uk/ac/wellcome/storage/vhs/VHSIndexEntry.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/vhs/VHSIndexEntry.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.storage.vhs
 
-case class VHSEntry[M](
+case class VHSIndexEntry[M](
   hybridRecord: HybridRecord,
   metadata: M
 )

--- a/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -61,7 +61,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
             VHSIndexEntry(storedHybridRecord, storedMetadata),
             storedS3Record
           )
-        ) =>
+          ) =>
         debug(s"Existing object $id")
         val (transformedS3Record, transformedMetadata) =
           ifExisting(storedS3Record, storedMetadata)
@@ -182,10 +182,10 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
         objectStore
           .get(hybridRecord.location)
           .map { s3Object =>
-            Some(VersionedHybridObject(
-              vhsIndexEntry = vhsIndexEntry,
-              s3Object = s3Object)
-            )
+            Some(
+              VersionedHybridObject(
+                vhsIndexEntry = vhsIndexEntry,
+                s3Object = s3Object))
           }
       }
       case None => Future.successful(None)

--- a/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -79,7 +79,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
           ).map { hybridRecord =>
             VHSEntry(
               hybridRecord = hybridRecord,
-              metadata = storedMetadata
+              metadata = transformedMetadata
             )
           }
         } else {

--- a/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
+++ b/src/main/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStore.scala
@@ -31,7 +31,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
   )
 
   private case class VersionedHybridObject(
-    vhsEntry: VHSEntry[Metadata],
+    vhsIndexEntry: VHSIndexEntry[Metadata],
     s3Object: T
   )
 
@@ -54,11 +54,11 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
     updateExpressionGenerator: UpdateExpressionGenerator[DynamoRow],
     migrationH: Migration[DynamoRow, HybridRecord],
     migrationM: Migration[DynamoRow, Metadata]
-  ): Future[VHSEntry[Metadata]] =
+  ): Future[VHSIndexEntry[Metadata]] =
     getObject[DynamoRow](id).flatMap {
       case Some(
           VersionedHybridObject(
-            VHSEntry(storedHybridRecord, storedMetadata),
+            VHSIndexEntry(storedHybridRecord, storedMetadata),
             storedS3Record
           )
         ) =>
@@ -77,7 +77,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
                 metadata = transformedMetadata,
                 version = storedHybridRecord.version)
           ).map { hybridRecord =>
-            VHSEntry(
+            VHSIndexEntry(
               hybridRecord = hybridRecord,
               metadata = transformedMetadata
             )
@@ -85,7 +85,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
         } else {
           debug("existing object unchanged, not updating")
           Future.successful(
-            VHSEntry(
+            VHSIndexEntry(
               hybridRecord = storedHybridRecord,
               metadata = storedMetadata
             )
@@ -104,7 +104,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
             version = 0
           )
         ).map { hybridRecord =>
-          VHSEntry(
+          VHSIndexEntry(
             hybridRecord = hybridRecord,
             metadata = metadata
           )
@@ -174,7 +174,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
         val hybridRecord = dynamoRow.migrateTo[HybridRecord]
         val metadata = dynamoRow.migrateTo[Metadata]
 
-        val vhsEntry = VHSEntry(
+        val vhsIndexEntry = VHSIndexEntry(
           hybridRecord = hybridRecord,
           metadata = metadata
         )
@@ -183,7 +183,7 @@ class VersionedHybridStore[T, Metadata, Store <: ObjectStore[T]] @Inject()(
           .get(hybridRecord.location)
           .map { s3Object =>
             Some(VersionedHybridObject(
-              vhsEntry = vhsEntry,
+              vhsIndexEntry = vhsIndexEntry,
               s3Object = s3Object)
             )
           }

--- a/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
@@ -207,7 +207,8 @@ class StringStoreVersionedHybridStoreTest
                   (t, updatedMetadata))
               }
 
-              whenReady(updatedFuture) { _ =>
+              whenReady(updatedFuture) { vhsEntry: VHSEntry =>
+                vhsEntry.metadata shouldBe updatedMetadata
                 getRecordMetadata[ExtraData](table, id) shouldBe updatedMetadata
               }
             }

--- a/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
@@ -70,7 +70,7 @@ class StringStoreVersionedHybridStoreTest
           val future = hybridStore.updateRecord(id)(ifNotExisting =
             (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
-          whenReady(future) { case (hybridRecord, metadata) =>
+          whenReady(future) { case VHSEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 1
@@ -96,7 +96,7 @@ class StringStoreVersionedHybridStoreTest
               (updatedRecord, EmptyMetadata()))
           }
 
-          whenReady(updatedFuture) {case (hybridRecord, metadata) =>
+          whenReady(updatedFuture) {case VHSEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 2
@@ -121,7 +121,7 @@ class StringStoreVersionedHybridStoreTest
               (record, EmptyMetadata()))
           }
 
-          whenReady(updatedFuture) {case (hybridRecord, metadata) =>
+          whenReady(updatedFuture) {case VHSEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 1

--- a/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
@@ -70,7 +70,7 @@ class StringStoreVersionedHybridStoreTest
           val future = hybridStore.updateRecord(id)(ifNotExisting =
             (record, EmptyMetadata()))(ifExisting = (t, m) => (t, m))
 
-          whenReady(future) { case VHSEntry(hybridRecord, metadata) =>
+          whenReady(future) { case VHSIndexEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 1
@@ -96,7 +96,7 @@ class StringStoreVersionedHybridStoreTest
               (updatedRecord, EmptyMetadata()))
           }
 
-          whenReady(updatedFuture) {case VHSEntry(hybridRecord, metadata) =>
+          whenReady(updatedFuture) {case VHSIndexEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 2
@@ -121,7 +121,7 @@ class StringStoreVersionedHybridStoreTest
               (record, EmptyMetadata()))
           }
 
-          whenReady(updatedFuture) {case VHSEntry(hybridRecord, metadata) =>
+          whenReady(updatedFuture) {case VHSIndexEntry(hybridRecord, metadata) =>
             metadata shouldBe EmptyMetadata()
             hybridRecord.id shouldBe id
             hybridRecord.version shouldBe 1
@@ -207,7 +207,7 @@ class StringStoreVersionedHybridStoreTest
                   (t, updatedMetadata))
               }
 
-              whenReady(updatedFuture) { vhsEntry: VHSEntry[ExtraData] =>
+              whenReady(updatedFuture) { vhsEntry: VHSIndexEntry[ExtraData] =>
                 vhsEntry.metadata shouldBe updatedMetadata
                 getRecordMetadata[ExtraData](table, id) shouldBe updatedMetadata
               }

--- a/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
+++ b/src/test/scala/uk/ac/wellcome/storage/vhs/StringStoreVersionedHybridStoreTest.scala
@@ -207,7 +207,7 @@ class StringStoreVersionedHybridStoreTest
                   (t, updatedMetadata))
               }
 
-              whenReady(updatedFuture) { vhsEntry: VHSEntry =>
+              whenReady(updatedFuture) { vhsEntry: VHSEntry[ExtraData] =>
                 vhsEntry.metadata shouldBe updatedMetadata
                 getRecordMetadata[ExtraData](table, id) shouldBe updatedMetadata
               }


### PR DESCRIPTION
I think we should move towards a world where our applications pass around both the HybridRecord and the Metadata; not just the HybridRecord.

In particular, for https://github.com/wellcometrust/platform/issues/2984 we want to include some metadata about whether a Miro image is suitable for inclusion in the API, and passing around in this object seems ideal.