### PR TITLE
Only open streams we'll use in S3Copier

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Reduce the number of streams we open and discard in `S3Copier`.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Copier.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/s3/S3Copier.scala
@@ -18,27 +18,34 @@ class S3Copier(s3Client: AmazonS3) extends Logging with ObjectCopier {
   def copy(src: ObjectLocation, dst: ObjectLocation): Unit = {
     debug(s"Copying ${s3Uri(src)} -> ${s3Uri(dst)}")
 
-    val srcInput = getInputStream(src)
-    val dstInput = getInputStream(dst)
+    getInputStream(dst) match {
+      // If the destination object exists and is the same as the source
+      // object, we can skip the copy operation.
+      case Success(dstStream) =>
+        getInputStream(src) match {
+          case Success(srcStream) =>
+            compare(srcStream, dstStream)
 
-    // If the destination object exists and is the same as the
-    // source object, we can skip doing the copy.
-    (srcInput, dstInput) match {
-      case (Success(srcStream), Success(dstStream)) =>
-        compare(srcStream, dstStream)
-      case (Success(_), _)   => transferFile(src, dst)
-      case (Failure(err), _) => throw err
+            // Remember to close the streams afterwards, or we might get
+            // errors like
+            //
+            //    Unable to execute HTTP request: Timeout waiting for
+            //    connection from pool
+            //
+            // See: https://github.com/wellcometrust/platform/issues/3600
+            //      https://github.com/aws/aws-sdk-java/issues/269
+            //
+            srcStream.close()
+            dstStream.close()
+
+          case Failure(err) => {
+            dstStream.close()
+            throw err
+          }
+        }
+
+      case Failure(_) => transferFile(src, dst)
     }
-
-    // Remember to close the streams afterwards, or we might get errors like
-    //
-    //    Unable to execute HTTP request: Timeout waiting for connection from pool
-    //
-    // See: https://github.com/wellcometrust/platform/issues/3600
-    //      https://github.com/aws/aws-sdk-java/issues/269
-    //
-    srcInput.map { _.close() }
-    dstInput.map { _.close() }
 
     def compare(srcStream: InputStream, dstStream: InputStream): Unit = {
       if (IOUtils.contentEquals(srcStream, dstStream)) {


### PR DESCRIPTION
This patch means we don't open a stream for `src` if there's no `dst` object to compare to.  Doing so drops a warning in the logs (stream closed before all bytes were read) and is an unnecessary cost.

Part of wellcometrust/platform#3600.