### PR TITLE
Add a `join()` method to ObjectLocation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Add a `join()` method to `ObjectLocation` that lets you append to the key.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/ObjectLocation.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/ObjectLocation.scala
@@ -1,5 +1,11 @@
 package uk.ac.wellcome.storage
 
+import java.nio.file.Paths
+
 case class ObjectLocation(namespace: String, key: String) {
   override def toString = s"$namespace/$key"
+
+  def join(parts: String*): ObjectLocation = this.copy(
+    key = Paths.get(this.key, parts: _*).toString
+  )
 }

--- a/storage/src/test/scala/uk/ac/wellcome/storage/ObjectLocationTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/ObjectLocationTest.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.storage
+
+import org.scalatest.{FunSpec, Matchers}
+
+class ObjectLocationTest extends FunSpec with Matchers {
+  val namespace = "my_great_namespace"
+
+  it("can join with a single path") {
+    val root = ObjectLocation(namespace = namespace, key = "images/")
+    val file = ObjectLocation(namespace = namespace, key = "images/001.jpg")
+
+    root.join("001.jpg") shouldBe file
+  }
+
+  it("adds the trailing slash") {
+    val root = ObjectLocation(namespace = namespace, key = "images")
+    val file = ObjectLocation(namespace = namespace, key = "images/001.jpg")
+
+    root.join("001.jpg") shouldBe file
+  }
+
+  it("can join multiple parts") {
+    val root = ObjectLocation(namespace = namespace, key = "images")
+    val file = ObjectLocation(namespace = namespace, key = "images/red/dogs/001.jpg")
+
+    root.join("red", "dogs", "001.jpg") shouldBe file
+  }
+}

--- a/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/fixtures/S3.scala
@@ -101,7 +101,7 @@ trait S3 extends Logging with Eventually with IntegrationPatience with Matchers 
     //  - do not contain uppercase characters or underscores,
     //  - between 3 and 63 characters in length.
     // [https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules]
-    (Random.alphanumeric take 10 mkString).toLowerCase
+    randomAlphanumeric.toLowerCase
 
   def createBucket: Bucket =
     Bucket(createBucketName)


### PR DESCRIPTION
I feel like I've written the same pattern several times in the storage-service:

```scala
newLocation = existingObjectLocation.copy(
  key =
    Paths
      .get(x, y, z)
      .toString
)
```

This patch makes that code a little simpler:

```scala
newLocation = existingObjectLocation.join(x, y, z)
```