### PR TITLE
In the VHS, don't write to the store unless the underlying object has changed

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+In the VersionedHybridStore, when updating, don't write to the ObjectStore unless the underlying object has actually changed.

--- a/storage/src/test/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/vhs/VersionedHybridStoreTest.scala
@@ -154,6 +154,25 @@ class VersionedHybridStoreTest extends FunSpec with Matchers {
       result1 should not be result2
     }
 
+    it("skips writing to the store if only the metadata has changed") {
+      var putCount: Int = 0
+
+      val store = new MemoryObjectStore[Shape]() {
+        override def put(namespace: String)(input: Shape, keyPrefix: KeyPrefix, keySuffix: KeySuffix, userMetadata: Map[String, String]): Try[ObjectLocation] = {
+          putCount += 1
+          super.put(namespace)(input, keyPrefix, keySuffix, userMetadata)
+        }
+      }
+
+      val vhs = createVhs(store = store)
+
+      putCount shouldBe 0
+      storeNew(vhs, shape = triangle, metadata = metadataRed)
+      putCount shouldBe 1
+      storeUpdate(vhs, newShape = triangle, newMetadata = metadataBlue)
+      putCount shouldBe 1
+    }
+
     it("skips the update if nothing has changed") {
       val vhs = createVhs()
 


### PR DESCRIPTION
Faster and cheaper!

For #69, but this is small so let's hold it until that gets merged.