### PR TITLE
Don't store the indexed store ID twice in the HybridStore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Don't double-store the indexed store ID in the HybridStore.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/HybridStore.scala
@@ -4,8 +4,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage._
 
 case class HybridStoreEntry[T, Metadata](t: T, metadata: Metadata)
-case class HybridIndexedStoreEntry[IndexedStoreId, TypeStoreId, Metadata](
-  indexedStoreId: IndexedStoreId,
+case class HybridIndexedStoreEntry[TypeStoreId, Metadata](
   typedStoreId: TypeStoreId,
   metadata: Metadata
 )
@@ -15,7 +14,7 @@ trait HybridStore[IndexedStoreId, TypedStoreId, T, Metadata]
     with Logging {
 
   type IndexEntry =
-    HybridIndexedStoreEntry[IndexedStoreId, TypedStoreId, Metadata]
+    HybridIndexedStoreEntry[TypedStoreId, Metadata]
 
   implicit protected val indexedStore: Store[IndexedStoreId, IndexEntry]
   implicit protected val typedStore: TypedStore[TypedStoreId, T]
@@ -59,7 +58,6 @@ trait HybridStore[IndexedStoreId, TypedStoreId, T, Metadata]
         TypedStoreEntry(t.t, Map.empty))
 
       locationEntry = HybridIndexedStoreEntry(
-        indexedStoreId = id,
         typedStoreId = putTypeResult.id,
         metadata = t.metadata
       )

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStore.scala
@@ -11,7 +11,7 @@ class DynamoHybridStore[T, Metadata](prefix: ObjectLocationPrefix)(
   val indexedStore: DynamoHashStore[
     String,
     Int,
-    HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Metadata]],
+    HybridIndexedStoreEntry[ObjectLocation, Metadata]],
   val typedStore: S3TypedStore[T]
 ) extends HybridStore[Version[String, Int], ObjectLocation, T, Metadata] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreWithMaxima.scala
@@ -15,7 +15,7 @@ class DynamoHybridStoreWithMaxima[Id, V, T, Metadata](
   val indexedStore: DynamoHashRangeStore[
     Id,
     V,
-    HybridIndexedStoreEntry[Version[Id, V], ObjectLocation, Metadata]],
+    HybridIndexedStoreEntry[ObjectLocation, Metadata]],
   val typedStore: S3TypedStore[T]
 ) extends HybridStoreWithMaxima[Id, V, ObjectLocation, T, Metadata] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStore.scala
@@ -6,9 +6,8 @@ import uk.ac.wellcome.storage.streaming.Codec
 class MemoryHybridStore[Ident, T, Metadata](
   implicit
   val typedStore: MemoryTypedStore[String, T],
-  val indexedStore: MemoryStore[
-    Ident,
-    HybridIndexedStoreEntry[String, Metadata]],
+  val indexedStore: MemoryStore[Ident,
+                                HybridIndexedStoreEntry[String, Metadata]],
   val codec: Codec[T]
 ) extends HybridStore[Ident, String, T, Metadata] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStore.scala
@@ -8,7 +8,7 @@ class MemoryHybridStore[Ident, T, Metadata](
   val typedStore: MemoryTypedStore[String, T],
   val indexedStore: MemoryStore[
     Ident,
-    HybridIndexedStoreEntry[Ident, String, Metadata]],
+    HybridIndexedStoreEntry[String, Metadata]],
   val codec: Codec[T]
 ) extends HybridStore[Ident, String, T, Metadata] {
 

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
@@ -14,7 +14,7 @@ class MemoryHybridStoreWithMaxima[Id, T, Metadata](
   val typedStore: MemoryTypedStore[String, T],
   val indexedStore: Store[
     Version[Id, Int],
-    HybridIndexedStoreEntry[Version[Id, Int], String, Metadata]] with Maxima[
+    HybridIndexedStoreEntry[String, Metadata]] with Maxima[
     Id,
     Int],
   val codec: Codec[T]

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreWithMaxima.scala
@@ -14,9 +14,7 @@ class MemoryHybridStoreWithMaxima[Id, T, Metadata](
   val typedStore: MemoryTypedStore[String, T],
   val indexedStore: Store[
     Version[Id, Int],
-    HybridIndexedStoreEntry[String, Metadata]] with Maxima[
-    Id,
-    Int],
+    HybridIndexedStoreEntry[String, Metadata]] with Maxima[Id, Int],
   val codec: Codec[T]
 ) extends HybridStoreWithMaxima[Id, Int, String, T, Metadata] {
 

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/HybridStoreTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/HybridStoreTestCases.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.storage._
 
 trait HybridStoreTestCases[IndexedStoreId, TypedStoreId, T, Metadata, Namespace,
 TypedStoreImpl <: TypedStore[TypedStoreId, T],
-IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[IndexedStoreId, TypedStoreId, Metadata]],
+IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[TypedStoreId, Metadata]],
 HybridStoreContext] extends FunSpec with StoreTestCases[IndexedStoreId, HybridStoreEntry[T, Metadata], Namespace, HybridStoreContext]
   with Matchers
   with RandomThings
@@ -146,7 +146,6 @@ HybridStoreContext] extends FunSpec with StoreTestCases[IndexedStoreId, HybridSt
                 val metadata = createMetadata
 
                 val hybridIndexedStoreEntry = HybridIndexedStoreEntry(
-                  indexedStoreId = indexedStoreId,
                   typedStoreId = typedStoreId,
                   metadata = metadata
                 )
@@ -173,7 +172,6 @@ HybridStoreContext] extends FunSpec with StoreTestCases[IndexedStoreId, HybridSt
                 val metadata = createMetadata
 
                 val hybridIndexedStoreEntry = HybridIndexedStoreEntry(
-                  indexedStoreId = indexedStoreId,
                   typedStoreId = typedStoreId,
                   metadata = metadata
                 )
@@ -243,7 +241,7 @@ HybridStoreContext] extends FunSpec with StoreTestCases[IndexedStoreId, HybridSt
 trait HybridStoreWithOverwritesTestCases[
 IndexedStoreId, TypedStoreId, T, Metadata, Namespace,
 TypedStoreImpl <: TypedStore[TypedStoreId, T],
-IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[IndexedStoreId, TypedStoreId, Metadata]],
+IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[TypedStoreId, Metadata]],
 HybridStoreContext]
   extends HybridStoreTestCases[IndexedStoreId, TypedStoreId, T, Metadata, Namespace, TypedStoreImpl, IndexedStoreImpl, HybridStoreContext]
     with StoreWithOverwritesTestCases[IndexedStoreId, HybridStoreEntry[T, Metadata], Namespace, HybridStoreContext]
@@ -251,7 +249,7 @@ HybridStoreContext]
 trait HybridStoreWithoutOverwritesTestCases[
 IndexedStoreId, TypedStoreId, T, Metadata, Namespace,
 TypedStoreImpl <: TypedStore[TypedStoreId, T],
-IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[IndexedStoreId, TypedStoreId, Metadata]],
+IndexedStoreImpl <: Store[IndexedStoreId, HybridIndexedStoreEntry[TypedStoreId, Metadata]],
 HybridStoreContext]
   extends HybridStoreTestCases[IndexedStoreId, TypedStoreId, T, Metadata, Namespace, TypedStoreImpl, IndexedStoreImpl, HybridStoreContext]
     with StoreWithoutOverwritesTestCases[IndexedStoreId, HybridStoreEntry[T, Metadata], Namespace, HybridStoreContext]

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.store.HybridIndexedStoreEntry
 import org.scanamo.auto._
 
 class DynamoHybridStoreTest extends DynamoHybridStoreTestCases[
-  DynamoHashStore[String, Int, HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Map[String, String]]]
+  DynamoHashStore[String, Int, HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]]
   ] {
   override def createTable(table: Table): Table =
     createTableWithHashKey(table)
@@ -40,7 +40,7 @@ class DynamoHybridStoreTest extends DynamoHybridStoreTestCases[
 
     testWith(
       new DynamoIndexedStoreImpl(config = createDynamoConfigWith(table)) {
-        override def put(id: Version[String, Int])(t: HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Map[String, String]]): WriteEither =
+        override def put(id: Version[String, Int])(t: HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]): WriteEither =
           Left(StoreWriteError(new Error("BOOM!")))
       }
     )

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTestCases.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoHybridStoreTestCases.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.storage.generators.{MetadataGenerators, Record, RecordGene
 import uk.ac.wellcome.storage.store._
 import uk.ac.wellcome.storage.store.s3.{S3StreamStore, S3TypedStore}
 
-trait DynamoHybridStoreTestCases[DynamoStoreImpl <: Store[Version[String, Int], HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Map[String, String]]]]
+trait DynamoHybridStoreTestCases[DynamoStoreImpl <: Store[Version[String, Int], HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]]]
   extends HybridStoreWithoutOverwritesTestCases[
     Version[String, Int],
     ObjectLocation,
@@ -23,7 +23,7 @@ trait DynamoHybridStoreTestCases[DynamoStoreImpl <: Store[Version[String, Int], 
     ] with RecordGenerators with S3Fixtures with DynamoFixtures with MetadataGenerators {
   type S3TypedStoreImpl = S3TypedStore[Record]
   type DynamoIndexedStoreImpl = DynamoStoreImpl
-  type IndexedStoreEntry = HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Map[String, String]]
+  type IndexedStoreEntry = HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]
 
   def createPrefix(implicit context: (Bucket, Table)): ObjectLocationPrefix = {
     val (bucket, _) = context

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/dynamo/DynamoVersionedHybridStoreTest.scala
@@ -19,7 +19,7 @@ class DynamoVersionedHybridStoreTest extends VersionedStoreTestCases[String, Hyb
   with DynamoFixtures {
 
   type DynamoVersionedStoreImpl = DynamoVersionedHybridStore[String, Int, Record, Map[String, String]]
-  type IndexedStoreEntry = HybridIndexedStoreEntry[Version[String, Int], ObjectLocation, Map[String, String]]
+  type IndexedStoreEntry = HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]
 
   override def createTable(table: Table): Table =
     createTableWithHashRangeKey(table)

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryHybridStoreTest.scala
@@ -10,13 +10,13 @@ import uk.ac.wellcome.storage.store._
 class MemoryHybridStoreTest
   extends HybridStoreWithOverwritesTestCases[UUID, String, Record, Map[String, String], String,
     MemoryTypedStore[String, Record],
-    MemoryStore[UUID, HybridIndexedStoreEntry[UUID, String, Map[String, String]]],
-    (MemoryTypedStore[String, Record], MemoryStore[UUID, HybridIndexedStoreEntry[UUID, String, Map[String, String]]])]
+    MemoryStore[UUID, HybridIndexedStoreEntry[String, Map[String, String]]],
+    (MemoryTypedStore[String, Record], MemoryStore[UUID, HybridIndexedStoreEntry[String, Map[String, String]]])]
     with MetadataGenerators
     with RecordGenerators
     with MemoryTypedStoreFixtures[String, Record] {
 
-  type MemoryIndexedStoreImpl = MemoryStore[UUID, HybridIndexedStoreEntry[UUID, String, Map[String, String]]]
+  type MemoryIndexedStoreImpl = MemoryStore[UUID, HybridIndexedStoreEntry[String, Map[String, String]]]
   type MemoryTypedStoreImpl = MemoryTypedStore[String, Record]
 
   type Context = (MemoryTypedStoreImpl, MemoryIndexedStoreImpl)
@@ -86,7 +86,7 @@ class MemoryHybridStoreTest
   override def withBrokenPutIndexedStoreImpl[R](testWith: TestWith[MemoryIndexedStoreImpl, R])(implicit context: Context): R = {
     testWith(
       new MemoryIndexedStoreImpl(initialEntries = Map.empty) {
-        override def put(id: UUID)(t: HybridIndexedStoreEntry[UUID, String, Map[String, String]]): Either[WriteError, Identified[UUID, HybridIndexedStoreEntry[UUID, String, Map[String, String]]]] =
+        override def put(id: UUID)(t: HybridIndexedStoreEntry[String, Map[String, String]]): Either[WriteError, Identified[UUID, HybridIndexedStoreEntry[String, Map[String, String]]]] =
           Left(StoreWriteError(new Error("BOOM!")))
       }
     )
@@ -95,7 +95,7 @@ class MemoryHybridStoreTest
   override def withBrokenGetIndexedStoreImpl[R](testWith: TestWith[MemoryIndexedStoreImpl, R])(implicit context: Context): R = {
     testWith(
       new MemoryIndexedStoreImpl(initialEntries = Map.empty) {
-        override def get(id: UUID): Either[ReadError, Identified[UUID, HybridIndexedStoreEntry[UUID, String, Map[String, String]]]] =
+        override def get(id: UUID): Either[ReadError, Identified[UUID, HybridIndexedStoreEntry[String, Map[String, String]]]] =
           Left(StoreReadError(new Error("BOOM!")))
       }
     )

--- a/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/store/memory/MemoryVersionedHybridStoreTest.scala
@@ -11,7 +11,7 @@ class MemoryVersionedHybridStoreTest
     MemoryHybridStoreWithMaxima[String, Record, Record]]
     with RecordGenerators {
 
-  type IndexedStoreEntry = HybridIndexedStoreEntry[Version[String,Int], String, Record]
+  type IndexedStoreEntry = HybridIndexedStoreEntry[String, Record]
 
   override def withFailingGetVersionedStore[R](initialEntries: Entries)(testWith: TestWith[VersionedStoreImpl, R]): R = {
     withVersionedStoreContext { storeContext =>
@@ -61,8 +61,8 @@ class MemoryVersionedHybridStoreTest
   }
 
   override def withVersionedStoreContext[R](testWith: TestWith[MemoryHybridStoreWithMaxima[String, Record, Record], R]): R = {
-    val indexedStore = new MemoryStore[Version[String, Int], HybridIndexedStoreEntry[Version[String, Int], String, Record]](Map.empty)
-      with MemoryMaxima[String, HybridIndexedStoreEntry[Version[String, Int], String, Record]]
+    val indexedStore = new MemoryStore[Version[String, Int], HybridIndexedStoreEntry[String, Record]](Map.empty)
+      with MemoryMaxima[String, HybridIndexedStoreEntry[String, Record]]
 
     val memoryStoreForStreamStore = new MemoryStore[String, MemoryStreamStoreEntry](Map.empty)
     val streamStore = new MemoryStreamStore[String](memoryStoreForStreamStore)


### PR DESCRIPTION
We're storing redundant info (which is an unnecessary cost), and it opens the possibility of weirdness if the two IDs don't match.