### PR TITLE
Return NoMaximaValue if there's no max in DynamoHashStore

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug in DynamoHashStore where getting the `max()` of an ID that didn't exist would return a `DoesNotExistError`, not a `NoMaximaValueError`.

--- a/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
+++ b/storage/src/main/scala/uk/ac/wellcome/storage/store/dynamo/DynamoStore.scala
@@ -40,7 +40,11 @@ class DynamoHashStore[HashKey, V, T](val config: DynamoConfig)(
     with DynamoHashWritable[HashKey, V, T]
     with Maxima[HashKey, V] {
   override def max(hashKey: HashKey): Either[ReadError, V] =
-    getEntry(hashKey).map { _.version }
+    getEntry(hashKey).map { _.version } match {
+      case Right(value)               => Right(value)
+      case Left(_: DoesNotExistError) => Left(NoMaximaValueError())
+      case Left(err)                  => Left(err)
+    }
 
   override protected val table =
     Table[DynamoHashEntry[HashKey, V, T]](config.tableName)


### PR DESCRIPTION
And actually test it as a Maxima, which we weren't doing before. 🙈 

This is upstreaming a fix in the storage-service: https://github.com/wellcometrust/storage-service/blob/a4c7004d01389277e4e46cba8810be03f654c355/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTracker.scala#L34-L39

For https://github.com/wellcometrust/platform/issues/3703