### PR TITLE
Make sure we abort() rather than close() unused S3 input streams

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Fix a bug in S3Transfer where we weren't closing streams correctly, and the SDK would warn that you hadn't read all the bytes from an S3AbortableInputStream.

--- a/storage/src/test/scala/uk/ac/wellcome/storage/transfer/s3/S3TransferTest.scala
+++ b/storage/src/test/scala/uk/ac/wellcome/storage/transfer/s3/S3TransferTest.scala
@@ -6,12 +6,33 @@ import uk.ac.wellcome.storage.generators.{Record, RecordGenerators}
 import uk.ac.wellcome.storage.store.TypedStoreEntry
 import uk.ac.wellcome.storage.store.fixtures.BucketNamespaceFixtures
 import uk.ac.wellcome.storage.store.s3.S3TypedStore
-import uk.ac.wellcome.storage.transfer.TransferTestCases
+import uk.ac.wellcome.storage.transfer.{TransferSourceFailure, TransferTestCases}
 
-class S3TransferTest extends TransferTestCases[ObjectLocation, TypedStoreEntry[Record], Bucket, S3TypedStore[Record]] with S3TransferFixtures[Record] with RecordGenerators with BucketNamespaceFixtures {
+class S3TransferTest
+  extends TransferTestCases[ObjectLocation, TypedStoreEntry[Record], Bucket, S3TypedStore[Record]]
+    with S3TransferFixtures[Record]
+    with RecordGenerators
+    with BucketNamespaceFixtures {
   override def createSrcLocation(implicit bucket: Bucket): ObjectLocation = createId
 
   override def createDstLocation(implicit bucket: Bucket): ObjectLocation = createId
 
   override def createT: TypedStoreEntry[Record] = TypedStoreEntry(createRecord, metadata = Map.empty)
+
+  // This test is intended to spot warnings from the SDK if we don't close
+  // the dst inputStream correctly.
+  it("errors if the destination exists but the source does not") {
+    withLocalS3Bucket { bucket =>
+      val src = createObjectLocationWith(bucket)
+      val dst = createObjectLocationWith(bucket)
+
+      val initialEntries = Map(dst -> TypedStoreEntry(createRecord, metadata = Map.empty))
+
+      withTransferStore(initialEntries) { implicit store =>
+        withTransfer { transfer =>
+          transfer.transfer(src, dst).left.value shouldBe a[TransferSourceFailure[_]]
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This should clean up a warning we were seeing every time we used S3Transfer:

> Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection. This is likely an error and may result in sub-optimal behavior. Request only the bytes you need via a ranged GET or drain the input stream after use.

Closes https://github.com/wellcometrust/platform/issues/3707, closes https://github.com/wellcometrust/platform/issues/3728